### PR TITLE
Improve Overleaf compatibility

### DIFF
--- a/resources/UsersPackagesDefs.tex
+++ b/resources/UsersPackagesDefs.tex
@@ -126,7 +126,11 @@
 	\usepackage{derivative} % standard and customable derivative operators
 	\usepackage{siunitx} % International System units
 	% \usepackage{tensorsop} % work in progress ^^
-	\usepackage{tensorstyles}
+	\IfFileExists{tensorstyles.sty}{
+		\usepackage{tensorstyles}
+	}{
+		\PackageWarning{beamer-template_uge-inria}{tensorstyles.sty not found, skipping}
+	}
 		\newcommand{\glsarg}{}
 		\newcommand{\glsstar}{}
 		\NewDocumentCommand{\tsr}{s o m o}{


### PR DESCRIPTION
tensorstyles.sty is not available on Overleaf, which causes compilation to fail.

This patch makes the dependency optional to restore compatibility with Overleaf environments.